### PR TITLE
👷 ci: add ci for tests on backend

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run tests
         working-directory: ./backend/bittan
         run: |
+          timeout=30
+          start_time=$SECONDS
+
           ssh -o "StrictHostKeyChecking no" -R 80:localhost:8000 serveo.net > serveo.log 2>&1 &
           PID=$!
 
@@ -58,11 +61,15 @@ jobs:
             if grep -q 'HTTP' "serveo.log"; then
               break
             fi
+            if (( SECONDS - start_time >= timeout )); then
+              echo "Timeout reached. Exiting."
+              exit 1
+            fi
           done
 
           url=$(grep -oP 'https://[a-f0-9]+\.serveo\.net' "serveo.log")
           export APPLICATION_URL=$url
 
-          python3 manage.py test ./tests/bittan --exclude-tag=no_ci
+          python3 manage.py test ./bittan/tests --exclude-tag=no_ci
 
           kill $PID

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -48,9 +48,21 @@ jobs:
 
       - name: Run tests
         working-directory: ./backend/bittan
-        env:
-          APPLICATION_URL: "http://no-swish"
         run: |
-          python3 manage.py test bittan.tests.test_first
-          python3 manage.py test bittan.tests.views
-          : # python3 manage.py test bittan.tests.mail # cannot run mail tests without gmail_token.json
+          yes | ssh -R 80:localhost:8000 serveo.net > serveo.log 2>&1 &
+          PID=$!
+
+          while true; do
+            sleep 1
+            echo "Checking if Serveo is up..."
+            if grep -q 'HTTP' "serveo.log"; then
+              break
+            fi
+          done
+
+          url=$(ggrep -oP 'https://[a-f0-9]+\.serveo\.net' "serveo.log")
+          export APPLICATION_URL=$url
+
+          python3 manage.py test ./tests/bittan --exclude-tag=no_ci
+
+          kill $PID

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         working-directory: ./backend/bittan
         run: |
-          yes | ssh -R 80:localhost:8000 serveo.net > serveo.log 2>&1 &
+          ssh -o "StrictHostKeyChecking no" -R 80:localhost:8000 serveo.net > serveo.log 2>&1 &
           PID=$!
 
           while true; do
@@ -60,7 +60,7 @@ jobs:
             fi
           done
 
-          url=$(ggrep -oP 'https://[a-f0-9]+\.serveo\.net' "serveo.log")
+          url=$(grep -oP 'https://[a-f0-9]+\.serveo\.net' "serveo.log")
           export APPLICATION_URL=$url
 
           python3 manage.py test ./tests/bittan --exclude-tag=no_ci

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -1,0 +1,56 @@
+name: Backend Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: bittan_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=30
+
+    steps:
+      - name: Setup postgres etc/hosts
+        run: |
+          echo "127.0.0.1 postgres" | sudo tee -a /etc/hosts
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.13
+
+      - name: Install dependencies
+        working-directory: ./backend/bittan
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+
+      - name: Run tests
+        working-directory: ./backend/bittan
+        env:
+          APPLICATION_URL: "http://no-swish"
+        run: |
+          python3 manage.py test bittan.tests.test_first
+          python3 manage.py test bittan.tests.views
+          : # python3 manage.py test bittan.tests.mail # cannot run mail tests without gmail_token.json

--- a/backend/bittan/bittan/tests/mail/test_mail.py
+++ b/backend/bittan/bittan/tests/mail/test_mail.py
@@ -1,7 +1,8 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 from bittan.mail import send_mail, make_qr_image
 from bittan.mail import MailError, InvalidRecieverAddressError
 
+@tag("no_ci")
 class SendMailTest(TestCase):
 
 	def setUp(self):
@@ -30,6 +31,7 @@ class QRCodeTest(TestCase):
 		self.assertEqual(type(qr), bytes)
 		self.assertGreater(len(qr), 1)
 
+	@tag("no_ci")
 	def test_send_qr_in_mail(self):
 		qr = make_qr_image("This is some content!")
 		send_mail("bittantest@gmail.com", "QR Test", "This test mail contains a QR code.", qr)


### PR DESCRIPTION
Add CI to automatically run tests on backend when someone pushes to main or creates a PR into main. This will make sure all code merged into main passes the test-suite.

Currently does not run mail tests as these require `gmail_token.json` file. We probably do not want it to send mail on every commit/pr as well. If we want to add these tests as well the content of `gmail_token.json` should be added under `Settings > Secrets and Variables > Action Secrets` and a step can write the secret into the `gmail_token.json` file.

A benefit of running the mail tests as well is that we would be able to run all tests. As I found no clean way of excluding the mail tests.