### PR TITLE
Change from callback to signal

### DIFF
--- a/backend/bittan/bittan/apps.py
+++ b/backend/bittan/bittan/apps.py
@@ -10,7 +10,6 @@ class BittanConfig(AppConfig):
 
     def ready(self):
         from bittan.services.swish.swish import Swish 
-        from bittan.services.swish.example_callback_handler import example_callback_handler_function
 
         swish_url = EnvVars.get(ENV_VAR_NAMES.SWISH_API_URL)
         callback_url = f'{EnvVars.get(ENV_VAR_NAMES.APPLICATION_URL)}swish/callback/'
@@ -23,4 +22,8 @@ class BittanConfig(AppConfig):
         payee_alias = EnvVars.get(ENV_VAR_NAMES.SWISH_PAYEE_ALIAS)
 
         # Attach the Swish instance to a variable in the app's config for easy access
-        self.swish = Swish(swish_url, payee_alias, callback_url, cert_file_paths, example_callback_handler_function)
+        self.swish = Swish(swish_url, payee_alias, callback_url, cert_file_paths)
+
+        from bittan.services.swish.swish import payment_signal
+        from bittan.services.swish.example_callback_handler import example_callback_handler_function
+        payment_signal.connect(example_callback_handler_function)

--- a/backend/bittan/bittan/services/swish/example_callback_handler.py
+++ b/backend/bittan/bittan/services/swish/example_callback_handler.py
@@ -1,20 +1,26 @@
 from bittan.services.swish.swish_payment_request import SwishPaymentRequest, PaymentStatus
+from bittan.services.swish.swish import payment_signal
 
-def example_callback_handler_function(paymentRequest: SwishPaymentRequest):
+def example_callback_handler_function(sender, **kwargs):
 	""" 
 	An example of how the rest of the app can use the "swish-module". 
 	The callback handler should be specified when initializing, the "Swish" class. 
 	
 	This callback is called whenever a payment status changes, e.g succeeds or is cancelled.
 	"""
-	print("~~EXAMPLE CALLBACK HANDLER~~")
-	print("Payment status: ", paymentRequest.status)
 
-	if paymentRequest.is_paid():
-		print(f'Marking {paymentRequest.id} as paid')
-	elif paymentRequest.status == PaymentStatus.CANCELLED.value:
-		print(f'Payment {paymentRequest.id} failed because: {paymentRequest.status}')
-	elif paymentRequest.status == PaymentStatus.CREATED.value:
-		print(f'Payment {paymentRequest.id} is waiting...')
-	elif paymentRequest.status == PaymentStatus.ROGUE.value:
+	payment_request = kwargs["payment_request"]
+
+	print("~~EXAMPLE CALLBACK HANDLER~~")
+	print("Payment status: ", payment_request.status)
+
+	if payment_request.is_paid():
+		print(f'Marking {payment_request.id} as paid')
+	elif payment_request.status == PaymentStatus.CANCELLED.value:
+		print(f'Payment {payment_request.id} failed because: {payment_request.status}')
+	elif payment_request.status == PaymentStatus.CREATED.value:
+		print(f'Payment {payment_request.id} is waiting...')
+	elif payment_request.status == PaymentStatus.ROGUE.value:
 		print(f'This needs to be handled cearefully.')
+
+


### PR DESCRIPTION
Previously a callback function was added to the Swish class to be used for when swish notifies us about an update on a payment. This is now switched for the build in django signal.